### PR TITLE
Introduce id_column; delete lines with duplicate ID

### DIFF
--- a/lib/csv_patch/batches.rb
+++ b/lib/csv_patch/batches.rb
@@ -11,6 +11,7 @@ module CsvPatch
       @intermediate_files = []
       @input, @output     = options[:input], options[:output]
       @batches            = StreamBatch.new(options[:changes], options[:batch_size] || DEFAULT_BATCH_SIZE)
+      @id_column          = options[:id_column]
     end
 
     def execute
@@ -29,7 +30,12 @@ module CsvPatch
     end
 
     def patch_options batch
-      { input: input_for_next_patch, output: output_for_next_patch(batch), changes: batch.changes }
+      {
+        input: input_for_next_patch,
+        output: output_for_next_patch(batch),
+        changes: batch.changes,
+        id_column: @id_column
+      }
     end
 
     def close_intermediate_files

--- a/lib/csv_patch/patch.rb
+++ b/lib/csv_patch/patch.rb
@@ -12,7 +12,9 @@ module CsvPatch
       @input, @output   = CSV.new(options[:input]), options[:output]
 
       @revision_result  = Tempfile.new(TEMPFILE_NAME)
-      @revision         = Revision.new(options[:changes], @revision_result)
+      @revision         = Revision.new(
+        options[:changes], @revision_result, options[:id_column]
+      )
     end
 
     def apply

--- a/test/csv_patch/csv_patch_test.rb
+++ b/test/csv_patch/csv_patch_test.rb
@@ -25,7 +25,11 @@ class CsvPatchTest < Minitest::Test
   def test_processes_the_changes_file_in_a_single_batch_if_the_batch_size_is_greater_than_the_number_of_changes
     patch = mock('patch')
     patch.expects(:apply).with().once
-    CsvPatch::Patch.expects(:new).with(changes: batch_including(@changes_repository), input: @input, output: @output).once.returns(patch)
+    CsvPatch::Patch
+      .expects(:new)
+      .with(changes: batch_including(@changes_repository), input: @input, output: @output, id_column: nil)
+      .once
+      .returns(patch)
 
     setup_changes_file_with @changes_repository
     CsvPatch.patch(input: @input, output: @output, changes: @changes, batch_size: 7)
@@ -40,22 +44,22 @@ class CsvPatchTest < Minitest::Test
 
     first_patch.expects(:apply)
     CsvPatch::Patch.expects(:new)
-      .with(changes: batch_including(@changes_repository.slice(0, 2)), input: @input, output: result_of_first_patch)
+      .with(changes: batch_including(@changes_repository.slice(0, 2)), input: @input, output: result_of_first_patch, id_column: nil)
       .once.returns(first_patch)
 
     second_patch.expects(:apply)
     CsvPatch::Patch.expects(:new)
-      .with(changes: batch_including(@changes_repository.slice(2, 2)), input: result_of_first_patch, output: result_of_second_patch)
+      .with(changes: batch_including(@changes_repository.slice(2, 2)), input: result_of_first_patch, output: result_of_second_patch, id_column: nil)
       .once.returns(second_patch)
 
     third_patch.expects(:apply)
     CsvPatch::Patch.expects(:new)
-      .with(changes: batch_including(@changes_repository.slice(4, 2)), input: result_of_second_patch, output: result_of_third_patch)
+      .with(changes: batch_including(@changes_repository.slice(4, 2)), input: result_of_second_patch, output: result_of_third_patch, id_column: nil)
       .once.returns(third_patch)
 
     fourth_patch.expects(:apply)
     CsvPatch::Patch.expects(:new)
-      .with(changes: batch_including([@changes_repository.last]), input: result_of_third_patch, output: @output)
+      .with(changes: batch_including([@changes_repository.last]), input: result_of_third_patch, output: @output, id_column: nil)
       .once.returns(fourth_patch)
 
     setup_changes_file_with @changes_repository


### PR DESCRIPTION
This is a quick and dirty fix for two problems:

1. Some CSV files don't have the ID in the first column. For these,
   CsvPatch would misbehave. (Not delete rows it should delete. Add rows
   instead of updating existing ones.) Allow the caller to configure
   which column CsvPatch assumes to contain the ID.

2. When there are multiple rows with the same ID, CsvPatch used to
   delete only the first. This is a consequence of how it distinguished
   between changes that update rows and changes that add rows. Change
   this mechanism in a dirty way to enable deletion of all rows with the
   given ID.

Don't add tests, for now, since we're planning to eliminate this gem
from our dependencies shortly.